### PR TITLE
Add tests for help and version flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ $ yo uninstall
 ```
 
 ## Usage
+Check the installed version:
+```shell,no_run
+$ yo --version
+ yo v0.2.1
+```
+
+Display help information:
+```shell,no_run
+$ yo --help
+```
+
 Get a quick answer
 ```shell,no_run
 $ yo what is the capital of france

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -5,4 +5,5 @@ sh tests/test_basic_queries.sh
 sh tests/test_static_flags.sh
 sh tests/test_local_flags.sh
 sh tests/test_online_flags.sh
+sh tests/test_help_and_version.sh
 #sh tests/test_commands.sh

--- a/tests/test_help_and_version.sh
+++ b/tests/test_help_and_version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# shellcheck enable=all
+
+# Test the --version flag
+version_output=$(src/main.sh --version)
+if echo "$version_output" | grep -qE '^yo v[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "Version flag output: $version_output"
+else
+    echo "Unexpected version output: $version_output" >&2
+    exit 1
+fi
+
+# Test the --help flag
+help_output=$(src/main.sh --help)
+if echo "$help_output" | grep -q "yo - A command-line AI assistant"; then
+    echo "Help flag output contains expected description"
+else
+    echo "Help output missing description" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add regression test covering `yo --help` and `yo --version`
- document version and help usage in README
- include new test in test suite

## Testing
- `sh tests/test_help_and_version.sh`
- `sh tests/test_all.sh` *(fails: yq: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c0c4afa48325b40d1a60e34ddcbf