### PR TITLE
fix URL comment in input validation

### DIFF
--- a/src/input_validation.sh
+++ b/src/input_validation.sh
@@ -103,7 +103,7 @@ check_path() {
 	fi
 }
 
-# Check if hte input is a url
+# Check if the input is a URL
 check_url() {
 
 	# Parse arguments


### PR DESCRIPTION
## Summary
- clarify URL validation comment in `check_url`

## Testing
- `sh tests/test_all.sh` *(fails: yq, bc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c1d0eb948325801ea1bc7104765a