### PR TITLE
Clarify token conversion comments

### DIFF
--- a/src/tokens.sh
+++ b/src/tokens.sh
@@ -10,7 +10,7 @@ tokens_to_characters() {
 	# Check that inputs are valid
 	check_integer tokens || return 1
 
-	# Calculate the number of characters and divide by four
+        # Calculate the number of characters using read_setting conversion values
 	characters=$(echo "scale=0; (${tokens} * $(read_setting general.characters_per_token)) / $(read_setting general.token_estimation_correction_factor)" | bc)
 
 	# Return result
@@ -29,7 +29,7 @@ characters_to_tokens() {
 	# Check that inputs are valid
 	check_integer characters || return 1
 
-	# Calculate the number of characters and divide by four
+        # Calculate the number of tokens using read_setting conversion values
 	tokens=$(echo "(((${characters} + $(read_setting general.characters_per_token) - 1) / $(read_setting general.characters_per_token)) * $(read_setting general.token_estimation_correction_factor))" | bc)
 
 	# Return result


### PR DESCRIPTION
## Summary
- Reference read_setting configuration when describing token-to-character conversion
- Reference read_setting configuration when describing character-to-token conversion

## Testing
- `sh tests/test_all.sh` *(fails: yq not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c22401148325b1566eab103ae01f