### PR TITLE
Fix TIFF pattern in content processing

### DIFF
--- a/src/content_processing.sh
+++ b/src/content_processing.sh
@@ -22,7 +22,7 @@ extract_file_info() {
 			return 1
 		}
 		;;
-	*.png | *.jpg | *.jpeg | *.tiff | .tif | *.bmp | *.gif | *.webp)
+	*.png | *.jpg | *.jpeg | *.tiff | *.tif | *.bmp | *.gif | *.webp)
 		file_info=$(tesseract "${source}" - 2>/dev/null) || {
 			echo "Error: Failed to extract text from image ${source}." >&2
 			return 1


### PR DESCRIPTION
## Summary
- Correct image file globbing to include `.tif` images in `content_processing.sh`

## Testing
- `sh tests/test_all.sh` *(fails: yq: not found, bc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c355b64083259c72a17eafa2db7e