### PR TITLE
feat: add deterministic web search

### DIFF
--- a/src/status_checks.sh
+++ b/src/status_checks.sh
@@ -3,7 +3,10 @@
 
 # Function that checks to see if the system is online
 system_is_online() {
-	ping -c 1 google.com >/dev/null 2>&1
+        if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
+                return 0
+        fi
+        ping -c 1 google.com >/dev/null 2>&1
 }
 
 # Function that checks to see if a model exists and download it if not

--- a/src/status_checks.sh
+++ b/src/status_checks.sh
@@ -3,10 +3,10 @@
 
 # Function that checks to see if the system is online
 system_is_online() {
-        if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
-                return 0
-        fi
-        ping -c 1 google.com >/dev/null 2>&1
+	if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
+		return 0
+	fi
+	ping -c 1 google.com >/dev/null 2>&1
 }
 
 # Function that checks to see if a model exists and download it if not

--- a/src/web_search.sh
+++ b/src/web_search.sh
@@ -4,19 +4,19 @@
 # Perform a web search with user-provided terms
 perform_search() {
 
-        # Parse arguments
-        terms=$1
+	# Parse arguments
+	terms=$1
 
-        # Check that inputs are valid
-        check_nonempty terms || return 1
+	# Check that inputs are valid
+	check_nonempty terms || return 1
 
-        if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
-            echo "${YO_TEST_WEB_SEARCH_RESPONSE}"
-            return 0
-        fi
+	if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
+		echo "${YO_TEST_WEB_SEARCH_RESPONSE}"
+		return 0
+	fi
 
-        # Example API call
-        url="$(read_setting search.google_cse.base_url)?key=$(read_setting search.google_cse.api_key)&cx=$(read_setting search.google_cse.id)&q=$(echo "${terms}" | sed 's/ /+/g')"
+	# Example API call
+	url="$(read_setting search.google_cse.base_url)?key=$(read_setting search.google_cse.api_key)&cx=$(read_setting search.google_cse.id)&q=$(echo "${terms}" | sed 's/ /+/g')"
 
 	# Perform search and extract relevant information
 	response=$(curl -s "${url}") || {

--- a/src/web_search.sh
+++ b/src/web_search.sh
@@ -11,8 +11,8 @@ perform_search() {
         check_nonempty terms || return 1
 
         if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
-                echo "${YO_TEST_WEB_SEARCH_RESPONSE}"
-                return 0
+            echo "${YO_TEST_WEB_SEARCH_RESPONSE}"
+            return 0
         fi
 
         # Example API call

--- a/src/web_search.sh
+++ b/src/web_search.sh
@@ -4,14 +4,19 @@
 # Perform a web search with user-provided terms
 perform_search() {
 
-	# Parse arguments
-	terms=$1
+        # Parse arguments
+        terms=$1
 
-	# Check that inputs are valid
-	check_nonempty terms || return 1
+        # Check that inputs are valid
+        check_nonempty terms || return 1
 
-	# Example API call
-	url="$(read_setting search.google_cse.base_url)?key=$(read_setting search.google_cse.api_key)&cx=$(read_setting search.google_cse.id)&q=$(echo "${terms}" | sed 's/ /+/g')"
+        if [ -n "${YO_TEST_WEB_SEARCH_RESPONSE:-}" ]; then
+                echo "${YO_TEST_WEB_SEARCH_RESPONSE}"
+                return 0
+        fi
+
+        # Example API call
+        url="$(read_setting search.google_cse.base_url)?key=$(read_setting search.google_cse.api_key)&cx=$(read_setting search.google_cse.id)&q=$(echo "${terms}" | sed 's/ /+/g')"
 
 	# Perform search and extract relevant information
 	response=$(curl -s "${url}") || {

--- a/tests/test_online_flags.sh
+++ b/tests/test_online_flags.sh
@@ -4,6 +4,7 @@
 . tests/utilities.sh
 
 # Run setup
+export YO_TEST_WEB_SEARCH_RESPONSE=$(printf '%s\n' '"title": "Sky color"' '"snippet": "The sky is blue."' '"title": "Mass comparison"' '"snippet": "The Earth weighs more than the Moon."')
 setup
 
 # Test the --surf flag


### PR DESCRIPTION
## Summary
- allow tests to bypass online check with `YO_TEST_WEB_SEARCH_RESPONSE`
- use `YO_TEST_WEB_SEARCH_RESPONSE` to supply deterministic web search data
- set `YO_TEST_WEB_SEARCH_RESPONSE` in the online flag tests for deterministic results

## Testing
- `black .`
- `sh tests/test_online_flags.sh` *(fails: Error in Yo: Failed to download "bartowski/Qwen_Qwen3-1.7B-GGUF"/"Qwen_Qwen3-1.7B-Q4_K_M.gguf".)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dc3b53348325847a2befb3fbb4ec