### PR TITLE
Avoid trimming reasoning tags in verbose mode

### DIFF
--- a/src/llm_session_management.sh
+++ b/src/llm_session_management.sh
@@ -193,9 +193,13 @@ generate_prompt() {
 }
 
 remove_reasoning_tags() {
+	if [ "${VERBOSE:-false}" = true ]; then
+		cat
+		return 0
+	fi
 
 	# Filter out <think> and <reasoning> tags produced by some models
-awk '
+	awk '
 /<(think|reasoning)>/{flag=1; next}
 /<\/(think|reasoning)>/{flag=0; next}
 !flag
@@ -294,17 +298,17 @@ start_llama_session() {
 	args="${args} --prompt \"${prompt}\""
 
 	# Start session
-        if [ "${VERBOSE}" = true ]; then
-                if ! eval "llama-cli ${args}" | remove_reasoning_tags; then
-                        echo "Error: llama-cli command failed while attempting to call ${repo_name}/${file_name}." >&2
-                        return 1
-                fi
-        else
-                if ! eval "llama-cli ${args} 2>/dev/null" | remove_reasoning_tags; then
-                        echo "Error: llama-cli command failed while attempting to call ${repo_name}/${file_name}." >&2
-                        return 1
-                fi
-        fi
+	if [ "${VERBOSE}" = true ]; then
+		if ! eval "llama-cli ${args}" | remove_reasoning_tags; then
+			echo "Error: llama-cli command failed while attempting to call ${repo_name}/${file_name}." >&2
+			return 1
+		fi
+	else
+		if ! eval "llama-cli ${args} 2>/dev/null" | remove_reasoning_tags; then
+			echo "Error: llama-cli command failed while attempting to call ${repo_name}/${file_name}." >&2
+			return 1
+		fi
+	fi
 
 	# Return successfully
 	return 0

--- a/tests/test_reasoning_tags.sh
+++ b/tests/test_reasoning_tags.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env sh
 # shellcheck enable=all
 
-. src/llm_session_management.sh
+. ./src/llm_session_management.sh
 
 sample='<think>
 reasoning
 </think>
 answer'
 
-result=$(printf '%s' "$sample" | remove_reasoning_tags)
+result=$(printf '%s' "${sample}" | remove_reasoning_tags)
 
-if [ "$result" = "answer" ]; then
-    echo "  ✅ Reasoning tags removed correctly"
-    exit 0
+if [ "${result}" = "answer" ]; then
+	echo "  ✅ Reasoning tags removed correctly"
 else
-    echo "  ❌ Failed to remove reasoning tags: $result" >&2
-    exit 1
+	echo "  ❌ Failed to remove reasoning tags: ${result}" >&2
+	exit 1
+fi
+
+VERBOSE=true
+result_verbose=$(printf '%s' "${sample}" | remove_reasoning_tags)
+
+if [ "${result_verbose}" = "${sample}" ]; then
+	echo "  ✅ Reasoning tags preserved when verbose"
+	exit 0
+else
+	echo "  ❌ Reasoning tags should have been preserved when verbose: ${result_verbose}" >&2
+	exit 1
 fi


### PR DESCRIPTION
## Summary
- Skip reasoning tag filtering when `VERBOSE` is true
- Test reasoning tag behavior with and without verbose flag
- Format reasoning tag handling scripts with shfmt

## Testing
- `shellcheck src/llm_session_management.sh tests/test_reasoning_tags.sh` *(SC2312, SC2154, SC2016 warnings)*
- `tests/test_reasoning_tags.sh`
- `sh tests/test_all.sh` *(fails: yq, bc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bb04f71483258eaed192b5341191